### PR TITLE
9th December 2023: 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## \[Unreleased\]
 
+## \[0.2.1\] - 2023-12-09
+
+### Changed
+
+  - Rewrote the [readme](README.md) file and updated the examples.
+  - Switched error handling from `std::error::Error` to `anyhow`.
+
 ## \[0.2.0\] - 2023-11-16
 
 ### Added
@@ -14,32 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Added the GFDL (GNU Free Documentation License) to the [docs/](docs/) folder.
   - Added documentation for the JSON configuration.
 
-### Fixed
-
-  - None.
-
 ### Changed
 
   - Instead of having hardcoded replacements, now they are determined by a JSON config file, modified by the user.
-
-### Removed
-
-  - None.
 
 ## \[0.1.0\] - 2023-10-13
 
 ### Added
 
   - Initial release of `file-normalizer-rs`.
-
-### Fixed
-
-  - None.
-
-### Changed
-
-  - None.
-
-### Removed
-
-  - None.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +53,7 @@ dependencies = [
 name = "file-normalizer-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_derive",
  "serde_json",
@@ -73,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
@@ -115,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -139,18 +146,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-normalizer-rs"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ structopt = "0.3"
 serde_derive = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+anyhow = "1.0"
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+BUILD_COMMAND = cargo build --release
+
+clean:
+	cargo clean
+	rm -rf ./file-normalizer-rs* Cargo.lock
+	cargo check
+	cargo clean
+windows-release:
+	$(BUILD_COMMAND) --target x86_64-pc-windows-gnu
+	mv target/x86_64-pc-windows-gnu/release/file-normalizer-rs.exe .
+	sha256sum file-normalizer-rs.exe > ./file-normalizer-rs.exe.sha256
+nix-release:
+	$(BUILD_COMMAND)
+	mv target/release/file-normalizer-rs .
+	sha256sum file-normalizer-rs > ./file-normalizer-rs.sha256

--- a/README.md
+++ b/README.md
@@ -6,47 +6,52 @@ This program takes an input file containing text with special characters and rep
 
 1.  [Installation](#installation)
 2.  [Usage](#usage)
-3.  [License](#license)
-4.  [Acknowledgments](#acknowledgments)
-5.  [Contact](#contact)
+3.  [Contributing](#contributing)
+4.  [License](#license)
 
 ## Installation
 
-To use this program, you'll need to install Rust and its package manager, Cargo. Follow the official [Rust installation guide](https://www.rust-lang.org/tools/install) to get them set up.
+To build this project from source, you'll need to install [rustup](https://rustup.rs/), if you don't have it already. Otherwise, you can download the precompiled binaries, from the Releases page.
 
 Once Rust and Cargo are installed, you can build and install this program using the following command:
 
-``` bash
-cargo install --path .
+```console
+$ cargo build --release
 ```
+
+If you'd like to, you can move the build executable (target/release/file-normalizer-rs) to wherever you'd like and run it.
 
 ## Usage
 
-After installing, you can use this program to normalize text files. Here's how to use it:
+After building from source, you can use this program to normalize text files.
 
-``` bash
-./file-normalizer-rs --input <input_file_path> --output <output_file_path> --config your_config_file.json
+```console
+$ ./file-normalizer-rs --input path/to/input.txt --output path/to/output.txt --config config_file.json
 ```
 
-Replace `<input_file_path>` with the path to the input text file that you want to normalize and `<output_file_path>` with the path where you want to save the normalized text.
+ For example:
 
-Example:
-
-``` bash
-./file-normalizer-rs -i input.txt -o output.txt -c file-normalizer.json
+```console
+$ ./file-normalizer-rs -i input.txt -o output.txt -c normalize.json
 ```
+
+## Contributing
+
+Contributions are always welcome! If you'd like to contribute, please:
+    - Follow the [code of conduct](CODE_OF_CONDUCT.md).
+    - Keep a consistent coding style. To make sure your coding style remains the same, format your code with:
+    ```console
+    $ rustfmt --edition 2021 path/to/source_code
+    ```
+    - Use Rust stable, rather than Rust nightly. If you notice my code contains code from Rust nightly,
+    feel free to change it to "stable" code.
+    - If you have to use an external library, please use lightweight ones
+    (eg. `ureq` over `reqwest`, `async-std` over `tokio`)
+    - Prefer using the standard library over reinventing the wheel.
+    - For proposing big changes, open an issue and describe:
+        - Why should the changes be implemented?
+        - What's the difference between using it and not using it?
 
 ## License
 
-This project is licensed under the GNU GPLv3 License. See the [LICENSE](LICENSE.md) file for details.
-
-## Acknowledgments
-
-I'd like to give credit to the following libraries and tools used in this project:
-
-  - [StructOpt](https://crates.io/crates/structopt) - for command-line argument parsing in Rust.
-  - [Serde](https://crates.io/crates/serde) - JSON parsing.
-
-## Contact
-
-If you have any questions or need further assistance, you can contact me at <walker84837@gmail.com>.
+This project is licensed under the [GNU General Public License, version 3](LICENSE.md).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,15 @@
-#![feature(rustc_private)]
-
+use anyhow::{Error, Result};
+use serde_derive::Deserialize;
 use std::{
-    fs::{read_to_string, write},
-    path::PathBuf,
+    fs,
     collections::HashMap,
+    path::PathBuf,
 };
-use serde_derive::{Serialize, Deserialize};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 struct Args {
-    /// Input file
+    /// File to normalize
     #[structopt(short = "i", long = "input", parse(from_os_str))]
     input_file: PathBuf,
 
@@ -18,48 +17,52 @@ struct Args {
     #[structopt(short = "o", long = "output", parse(from_os_str))]
     output_file: PathBuf,
 
-    /// JSON configuration file.
-    #[structopt(short = "c", long = "config", parse(from_os_str))]
-    config_path: Option<PathBuf>,
+    /// JSON configuration file
+    #[structopt(
+        short = "c",
+        long = "config",
+        default_value = "config.json",
+        parse(from_os_str)
+    )]
+    config_path: PathBuf,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize)]
 struct Config {
     changes: HashMap<String, String>,
 }
 
 pub fn normalize(text: &str, changes: &HashMap<String, String>) -> String {
-    changes.iter().fold(text.to_string(), |acc, (original, replacement)| {
-        acc.replace(original, replacement)
-    })
+    changes
+        .iter()
+        .fold(text.to_string(), |acc, (original, replacement)| {
+            acc.replace(original, replacement)
+        })
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     let args = Args::from_args();
 
     if !args.input_file.exists() {
-        eprintln!("Input file doesn't exist. Quitting...");
-        std::process::exit(1);
+        let error_msg = format!("Input file doesn't exist. Quitting...");
+        return Err(Error::msg(error_msg));
     }
 
-    let contents = read_to_string(&args.input_file)?;
+    let contents = fs::read_to_string(&args.input_file)?;
+    let config = fs::read_to_string(args.config_path)?;
 
-    let config_path = match args.config_path {
-        Some(path) => path,
-        None => PathBuf::from("config.json")
-    };
-
-    let config = read_to_string(config_path)?;
     let tmp: Config = serde_json::from_str(&config)?;
 
     let result = normalize(contents.as_str(), &tmp.changes);
-
-    write(&args.output_file, result.clone())?;
+    fs::write(&args.output_file, &result)?;
 
     if result != contents {
-        println!("File normalization complete. Replaced {} occurrences.", result.len());
+        println!(
+            "File normalization complete. Replaced {} occurrences.",
+            result.len()
+        );
     } else {
-        println!("No modifications needed.");
+        println!("INFO: Modifications were applied, but nothing changed.");
     }
 
     Ok(())


### PR DESCRIPTION
Update README, Makefile, and dependencies

- Rewrote the README.md file with clearer installation and usage instructions.
- Updated the Makefile to include separate targets for Windows and Unix releases.
- Bumped dependencies in Cargo.toml, including the introduction of the `anyhow` crate.
- Changed error handling from `std::error::Error` to `anyhow` in the main.rs file.